### PR TITLE
Pypi dependency fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
     url="https://github.com/tomquirk/realesate-com-au-api",
     license="MIT",
     packages=setuptools.find_packages(),
-    install_requires=["requests"],
+    install_requires=["requests", "fajita"],
     classifiers=(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
## Context

Currently, this package fails on import due to missing `fajita` dependency:

```
ModuleNotFoundError: No module named 'fajita'
```

## Changes

This is solved by adding fajita to the `install_requires` list in setup.py

## Reproduce/test

Commands
```
python3 -m pip uninstall -y fajita realestate_com_au_api && \
python3 -m pip install git+https://github.com/tomquirk/realestate-com-au-api && \
python3 -c 'import realestate_com_au; print(realestate_com_au.objects)'

python3 -m pip uninstall -y fajita realestate_com_au_api && \
python3 -m pip install git+https://github.com/tmck-code/realestate-com-au-api@pypi-fajita-dependency && \
python3 -c 'import realestate_com_au; print(realestate_com_au.objects)'
```

Output
```
[...]
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/freman/.local/lib/python3.7/site-packages/realestate_com_au/__init__.py", line 4, in <module>
    from .realestate_com_au import RealestateComAu
  File "/home/freman/.local/lib/python3.7/site-packages/realestate_com_au/realestate_com_au.py", line 10, in <module>
    from fajita import Fajita
ModuleNotFoundError: No module named 'fajita'
```

```
[...]
Successfully installed fajita-0.0.1b1 realestate-com-au-api-0.0.1b1
<module 'realestate_com_au' from '/home/freman/.local/lib/python3.7/site-packages/realestate_com_au/__init__.py'>
```

## Other PRs

I first made this PR here `https://github.com/tomquirk/realestate-com-au-api/pull/7` and submitted, but then had to branch off that in order to successfully test this change. The two changes (fajita and objects dir) solve all the pip installation problems, it works awesome after these small fixes