### PR TITLE
casted listing.description as str

### DIFF
--- a/realestate_com_au/realestate_com_au.py
+++ b/realestate_com_au/realestate_com_au.py
@@ -166,7 +166,7 @@ class RealestateComAu(Fajita):
                 listings = [
                     listing
                     for listing in listings
-                    if not re.search(pattern, listing.description)
+                    if not re.search(pattern, str(listing.description))
                 ]          
 
             return listings


### PR DESCRIPTION
casted listing.descriptoin as str, when you broaden your locations from "seventeen seventy, qld 4677" to "qld" for example some listing descriptions come back as NoneType and causes a TypeError during runtime.