### PR TITLE
Adapt Rounding to allow upper and lower case K and M

### DIFF
--- a/realestate_com_au/objects/listing.py
+++ b/realestate_com_au/objects/listing.py
@@ -49,7 +49,7 @@ class MediaItem:
     link: str
 
 def parse_price_text(price_display_text):
-    regex = r".*\$([0-9\,\.]+(?:k|m)*).*"
+    regex = r".*\$([0-9\,\.]+(?:k|K|m|M)*).*"
     price_groups = re.search(regex, price_display_text)
     price_text = (
         price_groups.groups()[
@@ -59,11 +59,11 @@ def parse_price_text(price_display_text):
         return None
 
     price = None
-    if price_text[-1] == "k":
+    if price_text[-1] == "k" or price_text[-1] == "K":
         price = float(price_text[:-1].replace(",", ""))
 
         price *= 1000
-    elif price_text[-1] == "m":
+    elif price_text[-1] == "m" or price_text[-1] == "M":
         price = float(price_text[:-1].replace(",", ""))
         price *= 1000000
     else:


### PR DESCRIPTION
I found that the parsed price text sometimes returned results that were too low. (545 instead of 545000)
Another example was that $1.4M was turned into '1'

This push request makes a minor adaption to allow both upper and lower case abbreviations to correctly be read.
Was previously only designed for lower case 'k' or lower case 'm'. 

## Test Suburb: 'Ascot Park SA 5043'
Output is shown in the far right column.

### Previous Code State

ID        | txt  |   price
----------|------|----
139803863 |44 Adelaide Terrace $595K Auction Saturday 30th July 1.00PM    |  595❗️
139258895 |1-3/38 Audrey Street $650K                                     | 650❗️


### New Code Output 

ID        | txt  |   price
----------|------|----
139803863 | 44 Adelaide Terrace $595K Auction Saturday 30th July 1.00PM | 595000 ✅
139258895 | 1-3/38 Audrey Street $650K | 650000 ✅
