### PR TITLE
Fix sorting option

### DIFF
--- a/realestate_com_au/realestate_com_au.py
+++ b/realestate_com_au/realestate_com_au.py
@@ -79,7 +79,7 @@ class RealestateComAu(Fajita):
         construction_status=None,  # NEW, ESTABLISHED
         keywords=[],
         exclude_keywords=[],
-        sort_type=None,
+        sort_type="relevance", # // "relevance", "price-desc", "price-asc", "new-desc", "new-asc", "next-inspection-time", "next-auction-time"
     ):
         def get_query_variables(page=start_page):
             query_variables = {
@@ -130,7 +130,7 @@ class RealestateComAu(Fajita):
             if keywords:
                 query_variables["filters"]["keywords"] = {"terms": keywords}
             if sort_type:
-                query_variables["sort_type"]=sort_type
+                query_variables["sortType"]=sort_type
             return query_variables
 
         def get_query():


### PR DESCRIPTION
It appears that there was a typo when crafting the sorting query:

```python
query_variables["sort_type"]=sort_type
```

but the actual query on the website uses camelcase 
![image](https://github.com/tomquirk/realestate-com-au-api/assets/105213357/2c0691ab-d942-436c-bc83-10c017705e45)

So I made a quick fix 🙂 